### PR TITLE
Updated fourseven:scss to 3.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Thanks to [@sveinburne](https://github.com/sveinburne)
 - **If you have update problems try to remove `juliancwirko:zf5` and `fourseven:scss` and then add `juliancwirko:zf5`** See: [#9](https://github.com/juliancwirko/meteor-zf5/issues/9)
 
 ### Change log
-
+- v3.0.0 fourseven:scss update (v3.8.1)
 - v2.0.2 fourseven:scss update (v3.4.1)
 - v2.0.1 Foundation 5.5.3 adjustments
 - v2.0.0 new build plugin support with new fourseven:scss (v3.4.0-beta1)

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Foundation for Sites 5 with Scss",
-  version: "2.0.2",
+  version: "3.0.0",
   name: "juliancwirko:zf5",
   git: "https://github.com/juliancwirko/meteor-zf5.git",
 });

--- a/package.js
+++ b/package.js
@@ -6,10 +6,10 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-    api.imply('fourseven:scss@3.4.1');
+    api.imply('fourseven:scss@3.8.1');
 	api.use([
 		'jquery@1.11.4',
-		'fourseven:scss@3.4.1',
+		'fourseven:scss@3.8.1',
 	], 'client');
 
 	api.addFiles([


### PR DESCRIPTION
I've changed the fourseven:scss version references in package.js to use 3.8.1 to make it work with Meteor 1.3.5.1 and up (including Meteor 1.4).

However, fourseven:scss 3.8.* is not compatible with anything lower than Meteor 1.3.2.* series according to its Compatibility chart on its [Atmosphere page](https://atmospherejs.com/fourseven/scss). So I also bumped the major version to 3.0.0, as it would be be a breaking change for existing users. I also added 3.0.0 to the change log on the README file, as well.

If you need anything else from me or have questions, let me know!

--Matt Meloncon